### PR TITLE
Add extra browser info components

### DIFF
--- a/src/Battery/index.tsx
+++ b/src/Battery/index.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react'
+
+interface BatteryState {
+  level: number
+  charging: boolean
+}
+
+function Battery(){
+  const [battery, setBattery] = useState<BatteryState | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const nav = navigator as any
+    if (!nav.getBattery) {
+      setError('Not supported')
+      return
+    }
+    nav.getBattery().then((b: any) => {
+      const update = () => setBattery({ level: b.level, charging: b.charging })
+      update()
+      b.addEventListener('levelchange', update)
+      b.addEventListener('chargingchange', update)
+    }).catch(() => setError('Unavailable'))
+  }, [])
+
+  return(
+    <div className='box-blue'>
+      <h2 className='title'>Battery</h2>
+      <div className='content'>
+        <img src='/img/ipaddress.svg' alt='battery' />
+        {error ? <p>{error}</p> : battery ? (
+          <p>{Math.round(battery.level * 100)}% {battery.charging ? '(charging)' : ''}</p>
+        ) : <p>Loading...</p>}
+      </div>
+    </div>
+  )
+}
+
+export default Battery

--- a/src/MainApp/index.tsx
+++ b/src/MainApp/index.tsx
@@ -15,6 +15,13 @@ import Network from '../Network'
 import Tracking from '../Tracking'
 import Plugins from '../Plugins'
 import Referrer from '../Referrer'
+import Battery from '../Battery'
+import Orientation from '../Orientation'
+import WebGLInfo from '../WebGLInfo'
+import MediaDevices from '../MediaDevices'
+import Storage from '../Storage'
+import Preferences from '../Preferences'
+import Offline from '../Offline'
 
 const MainApp: React.FC = () => {
   const ua = useMemo(() => parser(), [])
@@ -65,6 +72,27 @@ const MainApp: React.FC = () => {
             </div>
             <div className='col-md-6 col-xl-4'>
               <Referrer />
+            </div>
+            <div className='col-md-6 col-xl-4'>
+              <Battery />
+            </div>
+            <div className='col-md-6 col-xl-4'>
+              <Orientation />
+            </div>
+            <div className='col-md-6 col-xl-4'>
+              <WebGLInfo />
+            </div>
+            <div className='col-md-6 col-xl-4'>
+              <MediaDevices />
+            </div>
+            <div className='col-md-6 col-xl-4'>
+              <Storage />
+            </div>
+            <div className='col-md-6 col-xl-4'>
+              <Preferences />
+            </div>
+            <div className='col-md-6 col-xl-4'>
+              <Offline />
             </div>
           </div>
         </div>

--- a/src/MediaDevices/index.tsx
+++ b/src/MediaDevices/index.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react'
+
+interface DeviceInfo {
+  deviceId: string
+  kind: string
+  label: string
+}
+
+function MediaDevices(){
+  const [devices, setDevices] = useState<DeviceInfo[]>([])
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!navigator.mediaDevices || !navigator.mediaDevices.enumerateDevices) {
+      setError('Not supported')
+      return
+    }
+    navigator.mediaDevices.enumerateDevices().then(list => {
+      setDevices(list.map(d => ({ deviceId: d.deviceId, kind: d.kind, label: d.label || 'Unknown' })))
+    }).catch(() => setError('Permission denied'))
+  }, [])
+
+  return(
+    <div className='box-blue'>
+      <h2 className='title'>Media Devices</h2>
+      <div className='content'>
+        <img src='/img/ipaddress.svg' alt='media' />
+        {error ? <p>{error}</p> : devices.length ? (
+          <ul>
+            {devices.map(d => (
+              <li key={d.deviceId}><p>{d.kind}: {d.label}</p></li>
+            ))}
+          </ul>
+        ) : <p>None</p>}
+      </div>
+    </div>
+  )
+}
+
+export default MediaDevices

--- a/src/Offline/index.tsx
+++ b/src/Offline/index.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react'
+
+function Offline(){
+  const [online, setOnline] = useState<boolean>(navigator.onLine)
+  const [sw, setSw] = useState<number>(0)
+
+  useEffect(() => {
+    const update = () => setOnline(navigator.onLine)
+    window.addEventListener('online', update)
+    window.addEventListener('offline', update)
+    if (navigator.serviceWorker?.getRegistrations) {
+      navigator.serviceWorker.getRegistrations().then(r => setSw(r.length))
+    }
+    return () => {
+      window.removeEventListener('online', update)
+      window.removeEventListener('offline', update)
+    }
+  }, [])
+
+  return(
+    <div className='box-blue'>
+      <h2 className='title'>Connectivity</h2>
+      <div className='content'>
+        <img src='/img/ipaddress.svg' alt='offline' />
+        <ul>
+          <li><p>Online: {online ? 'yes' : 'no'}</p></li>
+          <li><p>Service Workers: {sw}</p></li>
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+export default Offline

--- a/src/Orientation/index.tsx
+++ b/src/Orientation/index.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react'
+
+interface OrientationState {
+  alpha: number | null
+  beta: number | null
+  gamma: number | null
+}
+
+function Orientation(){
+  const [ori, setOri] = useState<OrientationState | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (typeof window.DeviceOrientationEvent === 'undefined') {
+      setError('Not supported')
+      return
+    }
+    const handler = (e: DeviceOrientationEvent) => {
+      setOri({ alpha: e.alpha, beta: e.beta, gamma: e.gamma })
+    }
+    window.addEventListener('deviceorientation', handler)
+    return () => window.removeEventListener('deviceorientation', handler)
+  }, [])
+
+  return(
+    <div className='box-blue'>
+      <h2 className='title'>Orientation</h2>
+      <div className='content'>
+        <img src='/img/ipaddress.svg' alt='orientation' />
+        {error ? <p>{error}</p> : ori ? (
+          <ul>
+            <li><p>Alpha: {ori.alpha}</p></li>
+            <li><p>Beta: {ori.beta}</p></li>
+            <li><p>Gamma: {ori.gamma}</p></li>
+          </ul>
+        ) : <p>Waiting...</p>}
+      </div>
+    </div>
+  )
+}
+
+export default Orientation

--- a/src/Preferences/index.tsx
+++ b/src/Preferences/index.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react'
+
+interface PrefState {
+  dark: boolean
+  saveData: boolean | undefined
+}
+
+function Preferences(){
+  const [pref, setPref] = useState<PrefState>({ dark: false, saveData: undefined })
+
+  useEffect(() => {
+    const darkMatch = window.matchMedia('(prefers-color-scheme: dark)')
+    const updateDark = () => setPref(p => ({ ...p, dark: darkMatch.matches }))
+    updateDark()
+    darkMatch.addEventListener('change', updateDark)
+    const saveData = (navigator as any).connection?.saveData
+    setPref(p => ({ ...p, saveData }))
+    return () => darkMatch.removeEventListener('change', updateDark)
+  }, [])
+
+  return(
+    <div className='box-blue'>
+      <h2 className='title'>Preferences</h2>
+      <div className='content'>
+        <img src='/img/ipaddress.svg' alt='pref' />
+        <ul>
+          <li><p>Dark Mode: {pref.dark ? 'yes' : 'no'}</p></li>
+          {pref.saveData !== undefined ? <li><p>Data Saver: {pref.saveData ? 'on' : 'off'}</p></li> : null}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+export default Preferences

--- a/src/Storage/index.tsx
+++ b/src/Storage/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+function Storage(){
+  const local = localStorage.length
+  const session = sessionStorage.length
+  const cookies = document.cookie ? document.cookie.split(';').length : 0
+
+  return(
+    <div className='box-blue'>
+      <h2 className='title'>Storage</h2>
+      <div className='content'>
+        <img src='/img/ipaddress.svg' alt='storage' />
+        <ul>
+          <li><p>localStorage: {local} keys</p></li>
+          <li><p>sessionStorage: {session} keys</p></li>
+          <li><p>Cookies: {cookies}</p></li>
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+export default Storage

--- a/src/WebGLInfo/index.tsx
+++ b/src/WebGLInfo/index.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react'
+
+interface GpuInfo {
+  vendor: string
+  renderer: string
+}
+
+function WebGLInfo(){
+  const [info, setInfo] = useState<GpuInfo | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const canvas = document.createElement('canvas')
+    const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl')
+    if (!gl) {
+      setError('WebGL not supported')
+      return
+    }
+    const ext = gl.getExtension('WEBGL_debug_renderer_info') as any
+    if (ext) {
+      setInfo({
+        vendor: gl.getParameter(ext.UNMASKED_VENDOR_WEBGL),
+        renderer: gl.getParameter(ext.UNMASKED_RENDERER_WEBGL)
+      })
+    } else {
+      setError('Renderer info not available')
+    }
+  }, [])
+
+  return(
+    <div className='box-blue'>
+      <h2 className='title'>WebGL</h2>
+      <div className='content'>
+        <img src='/img/cpu.svg' alt='webgl' />
+        {error ? <p>{error}</p> : info ? (
+          <ul>
+            <li><p>Vendor: {info.vendor}</p></li>
+            <li><p>Renderer: {info.renderer}</p></li>
+          </ul>
+        ) : <p>Loading...</p>}
+      </div>
+    </div>
+  )
+}
+
+export default WebGLInfo


### PR DESCRIPTION
## Summary
- display more info from Browser: battery, orientation, GPU, media devices, storage details, user preferences and connectivity

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd11578ac832bac4a1b0051726392